### PR TITLE
feat: add websocket and constains header helpers.

### DIFF
--- a/http.go
+++ b/http.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 // ProxyWriter helps to capture response headers and status code
@@ -154,4 +155,23 @@ func RemoveHeaders(headers http.Header, names ...string) {
 	for _, h := range names {
 		headers.Del(h)
 	}
+}
+
+// IsWebsocketRequest determines if the specified HTTP request is a websocket handshake request.
+func IsWebsocketRequest(req *http.Request) bool {
+	return ConstainsHeader(req, "Connection", "upgrade") && ConstainsHeader(req, "Upgrade", "websocket")
+}
+
+// ConstainsHeader checks if the given header field is present if the given HTTP request.
+func ConstainsHeader(req *http.Request, name, value string) bool {
+	if name == "" || value == "" {
+		return false
+	}
+	items := strings.Split(req.Header.Get(name), ",")
+	for _, item := range items {
+		if value == strings.ToLower(strings.TrimSpace(item)) {
+			return true
+		}
+	}
+	return false
 }

--- a/http.go
+++ b/http.go
@@ -185,7 +185,7 @@ var DefaultTransport *http.Transport
 
 // init initializes the default transport
 func init() {
-	var transport = NewDefaultTransport()
+	var transport = NewDefaultPooledTransport()
 	EnsureTransporterFinalized(transport)
 	DefaultTransport = transport
 }

--- a/http_test.go
+++ b/http_test.go
@@ -6,14 +6,7 @@ import (
 	"testing"
 
 	"github.com/nbio/st"
-	. "gopkg.in/check.v1"
 )
-
-func TestUtils(t *testing.T) { TestingT(t) }
-
-type NetUtilsSuite struct{}
-
-var _ = Suite(&NetUtilsSuite{})
 
 // Make sure copy does it right, so the copied url
 // is safe to alter without modifying the other

--- a/http_test.go
+++ b/http_test.go
@@ -1,10 +1,12 @@
 package utils
 
 import (
-	. "gopkg.in/check.v1"
 	"net/http"
 	"net/url"
 	"testing"
+
+	"github.com/nbio/st"
+	. "gopkg.in/check.v1"
 )
 
 func TestUtils(t *testing.T) { TestingT(t) }
@@ -15,7 +17,7 @@ var _ = Suite(&NetUtilsSuite{})
 
 // Make sure copy does it right, so the copied url
 // is safe to alter without modifying the other
-func (s *NetUtilsSuite) TestCopyUrl(c *C) {
+func TestCopyUrl(t *testing.T) {
 	urlA := &url.URL{
 		Scheme:   "http",
 		Host:     "localhost:5000",
@@ -26,42 +28,79 @@ func (s *NetUtilsSuite) TestCopyUrl(c *C) {
 		User:     &url.Userinfo{},
 	}
 	urlB := CopyURL(urlA)
-	c.Assert(urlB, DeepEquals, urlA)
+	st.Expect(t, urlB, urlA)
 	urlB.Scheme = "https"
-	c.Assert(urlB, Not(DeepEquals), urlA)
+	st.Reject(t, urlB, urlA)
 }
 
 // Make sure copy headers is not shallow and copies all headers
-func (s *NetUtilsSuite) TestCopyHeaders(c *C) {
+func TestCopyHeaders(t *testing.T) {
 	source, destination := make(http.Header), make(http.Header)
 	source.Add("a", "b")
 	source.Add("c", "d")
 
 	CopyHeaders(destination, source)
 
-	c.Assert(destination.Get("a"), Equals, "b")
-	c.Assert(destination.Get("c"), Equals, "d")
+	st.Expect(t, destination.Get("a"), "b")
+	st.Expect(t, destination.Get("c"), "d")
 
 	// make sure that altering source does not affect the destination
 	source.Del("a")
-	c.Assert(source.Get("a"), Equals, "")
-	c.Assert(destination.Get("a"), Equals, "b")
+	st.Expect(t, source.Get("a"), "")
+	st.Expect(t, destination.Get("a"), "b")
 }
 
-func (s *NetUtilsSuite) TestHasHeaders(c *C) {
+func TestHasHeaders(t *testing.T) {
 	source := make(http.Header)
 	source.Add("a", "b")
 	source.Add("c", "d")
-	c.Assert(HasHeaders([]string{"a", "f"}, source), Equals, true)
-	c.Assert(HasHeaders([]string{"i", "j"}, source), Equals, false)
+	st.Expect(t, HasHeaders([]string{"a", "f"}, source), true)
+	st.Expect(t, HasHeaders([]string{"i", "j"}, source), false)
 }
 
-func (s *NetUtilsSuite) TestRemoveHeaders(c *C) {
+func TestRemoveHeaders(t *testing.T) {
 	source := make(http.Header)
 	source.Add("a", "b")
 	source.Add("a", "m")
 	source.Add("c", "d")
 	RemoveHeaders(source, "a")
-	c.Assert(source.Get("a"), Equals, "")
-	c.Assert(source.Get("c"), Equals, "d")
+	st.Expect(t, source.Get("a"), "")
+	st.Expect(t, source.Get("c"), "d")
+}
+
+func TestIsWebSocketRequest(t *testing.T) {
+	headers := make(http.Header)
+	headers.Set("Connection", "upgrade")
+	headers.Set("Upgrade", "websocket")
+	req := &http.Request{Header: headers}
+	st.Expect(t, IsWebsocketRequest(req), true)
+
+	headers = make(http.Header)
+	headers.Set("Connection", "keep-alive")
+	req = &http.Request{Header: headers}
+	st.Expect(t, IsWebsocketRequest(req), false)
+}
+
+func TestConstainsHeader(t *testing.T) {
+	tests := []struct {
+		header  string
+		value   string
+		matches bool
+	}{
+		{"foo", "bar", true},
+		{"bar", "foo", true},
+		{"Baz", "baz", false},
+		{"foo", "foo", false},
+		{"foo", "", false},
+		{"", "", false},
+	}
+
+	headers := make(http.Header)
+	headers.Set("Foo", "bar")
+	headers.Set("bar", "foo")
+	req := &http.Request{Header: headers}
+
+	for _, test := range tests {
+		st.Expect(t, ConstainsHeader(req, test.header, test.value), test.matches)
+	}
 }


### PR DESCRIPTION
Adds two generic functions that are useful to be generalized and reused, e.g: in package `forward`.

Please, remove the branch while merging.
